### PR TITLE
Don't intercept close request with Wizard open

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "no.tornado"
-version = "2.0.0-SNAPSHOT"
+version = "2.1.0"
 description = "JavaFX Framework for Kotlin"
 
 repositories {

--- a/src/main/java/tornadofx/Wizard.kt
+++ b/src/main/java/tornadofx/Wizard.kt
@@ -218,21 +218,6 @@ abstract class Wizard @JvmOverloads constructor(title: String? = null, heading: 
             }
             oldPage?.callOnUndock()
         }
-
-        runLater {
-            // For when the instance is created
-            currentStage?.setOnCloseRequest {
-                it.consume()
-                onCancel()
-            }
-            // For when the instance is reused and the stage is changed
-            root.sceneProperty().select { it.windowProperty() }.onChange {
-                it?.setOnCloseRequest {
-                    it.consume()
-                    onCancel()
-                }
-            }
-        }
     }
 
     override fun onDock() {


### PR DESCRIPTION
When docking the wizard in window (not using a modal) the onCloseRequest will continue to be consumed even after the Wizard is done.

As such, this functionality is removed. (Our use case is single window applications, to match the Android experience).